### PR TITLE
Add basic profiling script for solver samples

### DIFF
--- a/scripts/basic-profile.ts
+++ b/scripts/basic-profile.ts
@@ -1,0 +1,38 @@
+import { HighDensitySolverA01 } from "../lib/HighDensitySolverA01/HighDensitySolverA01"
+import sample001 from "../tests/dataset01/sample001/sample001.json"
+
+type ProfileSample = {
+  name: string
+  nodeWithPortPoints: typeof sample001
+  cellSizeMm: number
+  viaDiameter: number
+  maxIterations: number
+}
+
+const profileSamples: ProfileSample[] = [
+  {
+    name: "sample001",
+    nodeWithPortPoints: sample001,
+    cellSizeMm: 0.5,
+    viaDiameter: 0.3,
+    maxIterations: 1_000_000,
+  },
+]
+
+for (const sample of profileSamples) {
+  const solver = new HighDensitySolverA01({
+    nodeWithPortPoints: sample.nodeWithPortPoints,
+    cellSizeMm: sample.cellSizeMm,
+    viaDiameter: sample.viaDiameter,
+  })
+
+  solver.MAX_ITERATIONS = sample.maxIterations
+
+  const start = performance.now()
+  solver.solve()
+  const elapsedMs = performance.now() - start
+
+  console.log(
+    `${sample.name}: solve=${elapsedMs.toFixed(2)}ms solved=${solver.solved} failed=${solver.failed} iterations=${solver.iterations}`,
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a simple, runnable way to profile solver runtime on sample fixtures and make it easy to add more samples for benchmarking.

### Description
- Add `scripts/basic-profile.ts` which declares a `profileSamples` array (seeded with `sample001`) and constructs a `HighDensitySolverA01` per sample.
- The script sets `solver.MAX_ITERATIONS`, runs `solver.solve()`, measures elapsed time with `performance.now()`, and logs the duration along with `solved`, `failed`, and `iterations` fields.
- The script is designed to be executed with `bun run scripts/basic-profile.ts` and is easily extendable to additional samples.

### Testing
- Ran `bun run scripts/basic-profile.ts` which completed and printed timing and status (e.g. `sample001: solve=7316.63ms solved=true failed=false iterations=782607`).
- Ran `bun test tests/dataset01/sample001/sample001.test.ts` which failed due to tests using the `{ timeout: ... }` signature that is not accepted by the repo's `bun:test` typings/runtime.
- Ran `bunx tsc --noEmit` which reported type errors originating from the same test timeout typing mismatch.
- Attempted `bun run format` but no `format` script is defined in `package.json`, so formatting was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e56907434832e9b53d0d990877249)