### PR TITLE
Propagate regionId in route outputs

### DIFF
--- a/lib/HighDensitySolverA01/HighDensitySolverA01.ts
+++ b/lib/HighDensitySolverA01/HighDensitySolverA01.ts
@@ -1,10 +1,10 @@
 import { BaseSolver } from "@tscircuit/solver-utils"
+import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import {
   type AffineTransform,
   applyAffineTransformToPoint,
   computeGridToAffineTransform,
 } from "../gridToAffineTransform"
-import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import { computeMaxIterationsByNodeSizeAndConnectionCount } from "../maxIterationsByNodeSizeAndConnectionCount"
 import type {
   HighDensityIntraNodeRoute,
@@ -1558,6 +1558,7 @@ export class HighDensitySolverA01 extends BaseSolver {
         result.push({
           connectionName: connName,
           rootConnectionName: this.connIdToRootNet[connId],
+          regionId: this.nodeWithPortPoints.capacityMeshNodeId,
           traceThickness: this.traceThickness,
           viaDiameter: this.viaDiameter,
           route: points,

--- a/lib/HighDensitySolverA02/HighDensitySolverA02.ts
+++ b/lib/HighDensitySolverA02/HighDensitySolverA02.ts
@@ -1,10 +1,10 @@
 import { BaseSolver } from "@tscircuit/solver-utils"
 import Flatbush from "flatbush"
+import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import {
   type AffineTransform,
   applyAffineTransformToPoint,
 } from "../gridToAffineTransform"
-import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import type {
   HighDensityIntraNodeRoute,
   NodeWithPortPoints,
@@ -2254,6 +2254,7 @@ export class HighDensitySolverA02 extends BaseSolver {
       for (const route of routes) {
         result.push({
           connectionName: connName,
+          regionId: this.nodeWithPortPoints.capacityMeshNodeId,
           traceThickness: this.traceThickness,
           viaDiameter: this.viaDiameter,
           route: Array.from(route.states, (state) => {

--- a/lib/HighDensitySolverA03/HighDensitySolverA03.ts
+++ b/lib/HighDensitySolverA03/HighDensitySolverA03.ts
@@ -1,9 +1,9 @@
 import { BaseSolver } from "@tscircuit/solver-utils"
+import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import {
   type AffineTransform,
   applyAffineTransformToPoint,
 } from "../gridToAffineTransform"
-import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import { computeMaxIterationsByNodeSizeAndConnectionCount } from "../maxIterationsByNodeSizeAndConnectionCount"
 import type {
   HighDensityIntraNodeRoute,
@@ -2127,6 +2127,7 @@ export class HighDensitySolverA03 extends BaseSolver {
         }
         result.push({
           connectionName: connName,
+          regionId: this.nodeWithPortPoints.capacityMeshNodeId,
           traceThickness: this.traceThickness,
           viaDiameter: this.viaDiameter,
           route: points,

--- a/lib/HighDensitySolverA05/HighDensitySolverA05.ts
+++ b/lib/HighDensitySolverA05/HighDensitySolverA05.ts
@@ -1,9 +1,9 @@
 import { BaseSolver } from "@tscircuit/solver-utils"
+import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import {
   type AffineTransform,
   applyAffineTransformToPoint,
 } from "../gridToAffineTransform"
-import { getConnectionPortPointPairs } from "../getConnectionPortPointPairs"
 import { computeMaxIterationsByNodeSizeAndConnectionCount } from "../maxIterationsByNodeSizeAndConnectionCount"
 import {
   deriveViasFromRoutePoints,
@@ -2487,6 +2487,7 @@ export class HighDensitySolverA05 extends BaseSolver {
         result.push({
           connectionName: connName,
           rootConnectionName: this.connIdToRootNet[connId],
+          regionId: this.nodeWithPortPoints.capacityMeshNodeId,
           traceThickness: this.traceThickness,
           viaDiameter: this.viaDiameter,
           route: route.routePoints.map((point) => ({ ...point })),

--- a/lib/HighDensitySolverA09/HighDensitySolverA09.ts
+++ b/lib/HighDensitySolverA09/HighDensitySolverA09.ts
@@ -491,6 +491,8 @@ export class HighDensitySolverA09 extends BaseSolver {
         ...routes.map((route) => ({
           ...route,
           rootConnectionName: connection.rootConnectionName,
+          regionId:
+            route.regionId ?? this.nodeWithPortPoints.capacityMeshNodeId,
         })),
       )
       this.activeOrderConnectionIndex += 1

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -48,6 +48,7 @@ export type HighDensityIntraNodeRoute = {
   route: HighDensityRoutePoint[]
   vias: Array<{ x: number; y: number }>
   jumpers?: Jumper[]
+  regionId?: string
 }
 
 export type HighDensityRoute = HighDensityIntraNodeRoute


### PR DESCRIPTION
Adds regionId to high-density route output types and ensures A01/A02/A03/A05/A09/Wasm outputs preserve or emit the capacity mesh node id.\n\nCommit: ac8f940