### PR TITLE
Release A01 and A03 search state

### DIFF
--- a/lib/HighDensitySolverA01/HighDensitySolverA01.ts
+++ b/lib/HighDensitySolverA01/HighDensitySolverA01.ts
@@ -516,6 +516,34 @@ export class HighDensitySolverA01 extends BaseSolver {
     }
   }
 
+  release(): void {
+    this.usedCellsFlat = new Int32Array(0)
+    this.portOwnerFlat = new Int32Array(0)
+    this.usedDiagFlat = new Int32Array(0)
+    this.penalty2d = new Float64Array(0)
+    this.visitedStamp = new Uint32Array(0)
+    this.sharedCrossRootPortCells = new Set()
+    this.viaOffsetsDr = new Int32Array(0)
+    this.viaOffsetsDc = new Int32Array(0)
+    this.viaOffsetsLen = 0
+    this.usedIndicesByConn = []
+    this.usedDiagIndicesByConn = []
+    this.unsolvedSegs = []
+    this.activeConnSeg = null
+    this.activeConnId = -1
+    this.crossLayerSearch = false
+    this.nodePool = []
+    this.heap = new MinHeap()
+    this._viaOccs = []
+    this.ripCount = []
+    this.totalRipEvents = 0
+    this.searchIterations = 0
+    this.consecutiveSkips = 0
+    this.penaltyCap = 0
+    this.baseSearchBudgetIters = 0
+    this._moveRipped = null
+  }
+
   private stepOnce(): void {
     // 1. If no active connection, dequeue next
     if (!this.activeConnSeg) {

--- a/lib/HighDensitySolverA03/HighDensitySolverA03.ts
+++ b/lib/HighDensitySolverA03/HighDensitySolverA03.ts
@@ -701,6 +701,49 @@ export class HighDensitySolverA03 extends BaseSolver {
     }
   }
 
+  release(): void {
+    this.cellCenterX = new Float64Array(0)
+    this.cellCenterY = new Float64Array(0)
+    this.cellMinX = new Float64Array(0)
+    this.cellMinY = new Float64Array(0)
+    this.cellMaxX = new Float64Array(0)
+    this.cellMaxY = new Float64Array(0)
+    this.cellWidth = new Float64Array(0)
+    this.cellHeight = new Float64Array(0)
+    this.cellRegion = new Uint8Array(0)
+    this.cellRow = new Int32Array(0)
+    this.cellCol = new Int32Array(0)
+    this.viaAllowed = new Uint8Array(0)
+    this.neighborOffset = new Int32Array(0)
+    this.neighborIds = new Int32Array(0)
+    this.neighborCosts = new Float32Array(0)
+    this.usedCellsFlat = new Int32Array(0)
+    this.sharedCellsFlat = []
+    this.portOwnerFlat = new Int32Array(0)
+    this.penalty2d = new Float64Array(0)
+    this.visitedStamp = new Uint32Array(0)
+    this.bestGStamp = new Uint32Array(0)
+    this.bestGValue = new Float64Array(0)
+    this.visitedFlatStamp = new Uint32Array(0)
+    this.sharedCrossRootPortFlat = new Uint8Array(0)
+    this.usedIndicesByConn = []
+    this.unsolvedSegs = []
+    this.activeConnSeg = null
+    this.activeConnId = -1
+    this.nodePool = new TypedNodePool()
+    this.heap = new TypedMinHeap()
+    this.ripChain = new TypedRipChain()
+    this._viaOccs = []
+    this._cellOccs = []
+    this._rippedIds = []
+    this.ripCount = []
+    this.totalRipEvents = 0
+    this.searchIterations = 0
+    this.consecutiveSkips = 0
+    this.penaltyCap = 0
+    this.baseSearchBudgetIters = 0
+  }
+
   private buildFiveRegionGrid(width: number, height: number) {
     this.fineCols = Math.max(1, Math.ceil(width / this.highResolutionCellSize))
     this.fineRows = Math.max(1, Math.ceil(height / this.highResolutionCellSize))


### PR DESCRIPTION
## Summary

Add `release()` implementations to the A01 and A03 high-density solvers so the
autorouter can explicitly drop large search-state arrays once these package solvers
lose, fail, or finish.

Included here:

- `HighDensitySolverA01.release()`
- `HighDensitySolverA03.release()`

## Why

The autorouter-side HD cleanup now calls optional `release?.()` hooks on nested
candidate solvers. Without package-side implementations, A01/A03 instances keep
their large typed arrays and search-state pools alive until GC can reclaim the whole
solver object.

This PR lets the autorouter free that package-owned state promptly.

## Verification

```bash
bun run build
```

Result:

- build passes
